### PR TITLE
make multiple repl options work when run SendCurrentLine in other buffer.

### DIFF
--- a/autoload/repl.vim
+++ b/autoload/repl.vim
@@ -88,6 +88,7 @@ function! repl#REPLGetName()
                     if l:choice < 0 || l:choice >= l:count
                         throw "Unexpected-input-received"
                     else
+                        let g:repl_program[&filetype] = l:repl_options[l:choice]
                         return l:repl_options[l:choice]
                     endif
                 endfor


### PR DESCRIPTION
For #87 .

但是，存在一个问题，就是如果Close了REPL，下次Toggle就会直接打开上一次选择的环境（不再是有多个可以选择了）。

在考虑是否需要把之前的存到一个变量中，然后在Close函数中恢复`g:repl_program`.