### PR TITLE
Enable user customize code block begining and ending comment.

### DIFF
--- a/autoload/repl.vim
+++ b/autoload/repl.vim
@@ -679,13 +679,14 @@ function! repl#SendSession() abort
     endif
     let l:begin_line_number = line('.')
     let l:end_line_number = line('.')
-    for i in range(1, line('.'))
-        if repl#StartWith(getline(i), '# BEGIN')
+    for i in reverse(range(1, line('.')))
+        if repl#StartWith(getline(i), g:repl_code_block_begin)
             let l:begin_line_number = i
+            break
         endif
     endfor
     for i in range(line('.'), line('$'))
-        if repl#StartWith(getline(i), '# END')
+        if repl#StartWith(getline(i), g:repl_code_block_end)
             let l:end_line_number = i
             break
         endif

--- a/plugin/default.vim
+++ b/plugin/default.vim
@@ -104,3 +104,11 @@ endif
 if !exists('g:repl_unhide_when_send_lines')
     let g:repl_unhide_when_send_lines = 1
 endif
+
+if !exists('g:repl_code_block_begin')
+  let g:repl_code_block_begin = '# BEGIN'
+endif
+
+if !exists('g:repl_code_block_end')
+    let g:repl_code_block_end = '# END'
+endif


### PR DESCRIPTION
This commit enable customize begining and ending of code block. Like if `# %%` used and map Shift+Enter to `:REPLSendSession` it will have same behavior when use vscode and jupyter.