### PR TITLE
Fix error if comments were send to REPL.

### DIFF
--- a/autoload/formatpythoncode.py
+++ b/autoload/formatpythoncode.py
@@ -33,6 +33,8 @@ class pythoncodes:
     def getcode(self, code):
         self.rawcontents = [line for line in code if len(line.strip()) != 0]
         self.removecomments()
+        if len(self.rawcontents) == 0:
+            return self
         if self.flag_mergefinishline == 1:
             self.mergeunfinishline()
         self.analysepythonindent()
@@ -376,8 +378,10 @@ class pythoncodes:
 
 
     def generatecodes(self):
-        self.addbackspace()
         newcode = list()
+        if len(self.rawcontents) == 0:
+            return newcode
+        self.addbackspace()
         for i in range(len(self.blocks)):
             newcode += self.blocks[i][0]
         return newcode


### PR DESCRIPTION
## 问题说明

将代码送到REPL有时会把注释发送过去（逐行，或者使用notebook整个block都是注释），就会得到如下的提醒

```
处理 function repl#SendSession[19]..repl#SendLines[10]..repl#ToREPLPythonCode 时发生错误:
第   23 行:
Traceback (most recent call last):
  File "<string>", line 9, in <module>
  File "/home/roach/.vim/plugged/vim-repl/autoload/formatpythoncode.py", line 388, in format_to_repl
    pc.getcode(codes)
  File "/home/roach/.vim/plugged/vim-repl/autoload/formatpythoncode.py", line 37, in getcode
    self.mergeunfinishline()
  File "/home/roach/.vim/plugged/vim-repl/autoload/formatpythoncode.py", line 112, in mergeunfinishline
    tobeadded = self.rawcontents[j]
IndexError: list index out of range
```

## 改进

```
如果 if len(self.rawcontents) == 0:
	返回
```