### PR TITLE
Fix terminal buffer still left after run repl#REPLClose().

### DIFF
--- a/autoload/repl.vim
+++ b/autoload/repl.vim
@@ -201,6 +201,10 @@ function! repl#REPLClose()
             call term_sendkeys(repl#GetConsoleName(), "\<C-W>\<C-C>")
             call repl#Sends(['quit()'], ['ipdb>', 'pdb>'])
         else
+            call repl#REPLGoToWindowForBufferName(repl#GetConsoleName())
+            if mode() ==# 'n'
+                execute "normal! i"
+            endif
             exe "call term_sendkeys('" . repl#GetConsoleName() . ''', "\<C-W>\<C-C>")'
             exe "call term_wait('" . repl#GetConsoleName() . ''', 50)'
             if repl#REPLIsVisible()


### PR DESCRIPTION
If repl terminal in Terminal-Normal mode before run repl#REPLClose(), the terminal still there even the repl program is exited.