### PR TITLE
Fix for Issue148 - IPython version 8+

### DIFF
--- a/autoload/repl.vim
+++ b/autoload/repl.vim
@@ -285,7 +285,13 @@ function! repl#REPLOpen(...)
     if repl#REPLGetShortName() =~# '.*python.*'
         if repl#REPLGetShortName() == 'ipython' && !exists("g:repl_ipython_version")
             let temp = system(t:REPL_OPEN_TERMINAL . ' --version')
-            let g:repl_ipython_version = temp[0:2]
+			"This truncation was removed in part of fixing Issue #148
+			"I (shawsa) am not sure what purpose this served, and I can only
+			"test this on my particular configuration. It doesn't seem to have
+			"broken anything, but I'll leave the old code in in case it needs
+			"to be reverted (without reverting the other code in this commit).
+            let g:repl_ipython_version = temp
+			"let g:repl_ipython_version = temp[0:2]
         endif
         for l:i in range(1, line('$'))
             if repl#StartWith(getline(l:i), '#REPLENV:')

--- a/pythonx/formatpythoncode.py
+++ b/pythonx/formatpythoncode.py
@@ -266,7 +266,7 @@ class pythoncodes:
             elif self.replprogram == "ipython":
                 version = Version(self.version)
                 # print(f'{version=}, {self.version=}')
-                if version > Version('7.0'):
+                if version >= Version('7.1'):
                     return False
                 if line.startswith("pass ") or line.startswith("return ") or line.startswith("raise ") or line.startswith("continue ") or line.startswith("break "):
                     return True

--- a/pythonx/formatpythoncode.py
+++ b/pythonx/formatpythoncode.py
@@ -15,8 +15,45 @@ import replpython
 from filemanager import path
 import filemanager
 
+from itertools import zip_longest
+
 THREE_DOUBLEQUOTE = '"' * 3
 THREE_SINGLEQUOTE = '"' * 3
+
+class Version:
+    def __init__(self, version_string: str, name: str=None):
+        self.nums = tuple(map(int, version_string.split('.')))
+
+    def __repr__(self):
+        return f'Version({".".join(map(str, self.nums))})'
+
+    @property
+    def major(self):
+        return str(self.nums[0])
+
+    @property
+    def minor(self):
+        if len(self.nums) < 2:
+            return None
+        return '.'.join(map(str, self.nums[1:]))
+
+    def __iter__(self):
+        yield from self.nums
+
+    def __eq__(self, ver2):
+        return all(v1 == v2 for v1, v2 in zip_longest(self, ver2, fillvalue=0))
+
+    def __gt__(self, ver2):
+        for num1, num2 in zip_longest(self, ver2, fillvalue=0):
+            if num1 > num2:
+                return True
+            if num1 < num2:
+                return False
+        return False
+
+    def __ge__(self, ver2):
+        return self==ver2 or self>ver2
+
 
 class UnfinishType:
     LEFT_PARAENTHESE = 1 # (
@@ -227,7 +264,9 @@ class pythoncodes:
                 else:
                     return False
             elif self.replprogram == "ipython":
-                if self.version[0] == "7" and self.version != "7.0":
+                version = Version(self.version)
+                # print(f'{version=}, {self.version=}')
+                if version > Version('7.0'):
                     return False
                 if line.startswith("pass ") or line.startswith("return ") or line.startswith("raise ") or line.startswith("continue ") or line.startswith("break "):
                     return True


### PR DESCRIPTION
This should fix the problem for IPython 8.X at least.

I've created a `Version` class in `pythonx/formatpythoncode.py` that parses a version string and has convenient comparison functionality. It makes the logic more readable and functions properly for IPython versions greater than version 7.

While fixing this issue I noticed there was a line of code in `repl.vim` that truncates the version string. I have IPython version 8.14.0, but it was reading it as version 8.1. I'm not sure why this is done, but I've removed it and I don't think anything broke (for me at least). 