### PR TITLE
Fix ipython 8 indentation issue: add backspace like version <7.1

### DIFF
--- a/autoload/repl.vim
+++ b/autoload/repl.vim
@@ -142,6 +142,12 @@ function! repl#REPLGetShortName()
         return 'ipython'
     elseif l:temp ==# 'ipython3'
         return 'ipython'
+    elseif stridx(l:name, '--kernel=') != -1
+		if stridx(l:name, '--kernel=python') != -1
+			return 'ipython'
+		else
+			return 'R'
+		endif
     elseif l:temp =~# '.*python.*'
         return 'python'
     else

--- a/autoload/repl.vim
+++ b/autoload/repl.vim
@@ -554,7 +554,8 @@ function! repl#SendCurrentLine()
             endif
         endif
         if repl#REPLGetShortName() ==# "ipython"
-            call repl#Sends(repl#ToREPLPythonCode([l:code_tobe_sent], 'ipython'), ['\.\.\.', 'In'])
+            let l:code_line = substitute(l:code_tobe_sent, '\r\?\n$', '', '')
+            call repl#Sends([l:code_line], ['\.\.\.', 'In'])
         else
             call term_sendkeys(repl#GetConsoleName(), l:code_tobe_sent)
         endif

--- a/pythonx/formatpythoncode.py
+++ b/pythonx/formatpythoncode.py
@@ -266,7 +266,7 @@ class pythoncodes:
             elif self.replprogram == "ipython":
                 version = Version(self.version)
                 # print(f'{version=}, {self.version=}')
-                if version >= Version('7.1'):
+                if version >= Version('7.1') or version <= Version('8.0'):
                     return False
                 if line.startswith("pass ") or line.startswith("return ") or line.startswith("raise ") or line.startswith("continue ") or line.startswith("break "):
                     return True

--- a/pythonx/formatpythoncode.py
+++ b/pythonx/formatpythoncode.py
@@ -222,13 +222,12 @@ class pythoncodes:
         if not self.isstartofline(index):
             return False
         line = self.rawcontents[index].strip()
-        if line.startswith("else:"):
+        compact = "".join(line.split())
+        if line.startswith("else") and compact.startswith("else:"):
             return False
-        elif line.startswith("except "):
+        elif line.startswith("except ") or (line.startswith("except") and compact.startswith("except:")):
             return False
-        elif line.startswith("except:"):
-            return False
-        elif line.startswith("elif "):
+        elif line.startswith("elif ") or (line.startswith("elif") and compact.startswith("elif:")):
             return False
         else:
             return True


### PR DESCRIPTION
MWE:

def a(b):
    if b > 0:
        return 10
    else :
        return 5

Similar-to: https://github.com/sillybun/vim-repl/issues/156