### PR TITLE
`g:repl_position`  support `vspilt boright / topleft` open window

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,8 @@ it controls the location where REPL windows will appear
 - 1 represents top
 - 2 represents left
 - 3 represents right
-
+- 4 represents right most
+- 5 represents left most
 ```
 let g:repl_position = 0
 ```

--- a/autoload/repl.vim
+++ b/autoload/repl.vim
@@ -264,8 +264,12 @@ function! repl#REPLUnhide()
             exe 'to unhide'
         elseif g:repl_position == 2
             exe 'vert unhide'
-        else
+        elseif g:repl_position == 3
             exe 'vert rightb unhide'
+        elseif g:repl_position == 4
+            exe 'vert bo unhide'
+        else
+            exe 'vert to unhide'
         endif
     endif
 endfunction
@@ -317,11 +321,23 @@ function! repl#REPLOpen(...)
                     else
                         exe 'vert term ++close ' . repl#REPLGetShell()
                     endif
-                else
+                elseif g:repl_position == 3
                     if exists('g:repl_width')
                         exe 'vert rightb term ++close ++cols=' . float2nr(g:repl_width) . ' ' . repl#REPLGetShell()
                     else
                         exe 'vert rightb term ++close ' . repl#REPLGetShell()
+                    endif
+                elseif g:repl_position == 4
+                    if exists('g:repl_width')
+                        exe 'vert bo term ++close ++cols=' . float2nr(g:repl_width) . ' ' . repl#REPLGetShell()
+                    else
+                        exe 'vert bo term ++close ' . repl#REPLGetShell()
+                    endif
+                else
+                    if exists('g:repl_width')
+                        exe 'vert to term ++close ++cols=' . float2nr(g:repl_width) . ' ' . repl#REPLGetShell()
+                    else
+                        exe 'vert to term ++close ' . repl#REPLGetShell()
                     endif
                 endif
                 exe 'file ' . repl#GetConsoleName()
@@ -360,11 +376,23 @@ function! repl#REPLOpen(...)
                 else
                     exe 'vert term ++close ' . repl#REPLGetShell()
                 endif
-            else
+            elseif g:repl_position == 3
                 if exists('g:repl_width')
                     exe 'vert rightb term ++close ++cols=' . float2nr(g:repl_width) . ' ' . repl#REPLGetShell()
                 else
                     exe 'vert rightb term ++close ' . repl#REPLGetShell()
+                endif
+            elseif g:repl_position == 4
+                if exists('g:repl_width')
+                    exe 'vert bo term ++close ++cols=' . float2nr(g:repl_width) . ' ' . repl#REPLGetShell()
+                else
+                    exe 'vert bo term ++close ' . repl#REPLGetShell()
+                endif
+            else
+                if exists('g:repl_width')
+                    exe 'vert to term ++close ++cols=' . float2nr(g:repl_width) . ' ' . repl#REPLGetShell()
+                else
+                    exe 'vert to term ++close ' . repl#REPLGetShell()
                 endif
             endif
             exe 'file ' . repl#GetConsoleName()


### PR DESCRIPTION
Add support for g:repl_position values 4 (right-most) and 5 (left-most) to control REPL window placement. Update documentation and logic in autoload/repl.vim accordingly.